### PR TITLE
jQuery support for Dragster

### DIFF
--- a/src/dragster-jquery.coffee
+++ b/src/dragster-jquery.coffee
@@ -1,0 +1,34 @@
+class @DragsterJquery
+  constructor: ( @selector, @parent = document ) ->
+    if @supportsEventConstructors()
+      @first = false
+      @second = false
+
+      $(@parent).on "dragenter", selector, @dragenter
+      $(@parent).on "dragleave", selector, @dragleave
+
+      @dragsterEnterEvent = $.Event("dragster:enter")
+      @dragsterLeaveEvent = $.Event("dragster:leave")
+
+  dragenter: ( event ) =>
+    if @first
+      @second = true
+    else
+      @first = true
+      $(@parent).find(@selector).trigger(@dragsterEnterEvent)
+
+  dragleave: ( event ) =>
+    if @second
+      @second = false
+    else if @first
+      @first = false
+
+    if !@first && !@second
+      $(@parent).find(@selector).trigger(@dragsterLeaveEvent)
+
+  removeListeners: ->
+    $(@parent).off("dragenter dragleave", @selector)
+
+  supportsEventConstructors: ->
+    try new CustomEvent("z") catch then return false
+    return true

--- a/src/dragster.coffee
+++ b/src/dragster.coffee
@@ -31,7 +31,7 @@ class Dragster
     @el.removeEventListener "dragleave", @dragleave, false
 
   supportsEventConstructors: ->
-    try new CustomEvent("z") catch then return false
+    try new CustomEvent("z") catch e then return false
     return true
 
 


### PR DESCRIPTION
I've just created jQuery support for Dragster (in separate file, course).

It works like regular `Dragster` class but uses jQuery to provide smart event binding (like jquery `.on()`). One more feature of `DragsterJquery` is ability to define parent of element which will listen for Dragster events:

``` coffeescript
new DragsterJquery(element[, parent = document])
```

For example, if you want to isolate your drop area with specific ID you can do so by providing `parent` argument when instantiating class:

``` coffeescript
form = $('#customer_form')
new DragsterJquery('.drop_zone', form)

form.on 'dragster:enter', '.drop_zone', (e)->
  form.addClass('.hover')

form.on 'dragster:enter', '.drop_zone', (e)->
  form.removeClass('.hover')
```

Of course you can use both selectors and jQuery objects. Also `DragsterJquery` supports native `HTMLElement`.
